### PR TITLE
fix deprecated fields CorsPolicy.allow_origin and Cluster.hosts

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,31 +1,41 @@
 admin:
   access_log_path: /tmp/admin_access.log
   address:
-    socket_address: { address: 0.0.0.0, port_value: 9902 }
+    socket_address: {
+      address: 0.0.0.0,
+      port_value: 9902
+    }
 
 static_resources:
   listeners:
-  - name: login_listener
+  - name: access_listener
     address:
-      socket_address: { address: 0.0.0.0, port_value: 8989 }
+      socket_address: {
+        address: 0.0.0.0,
+        port_value: 8989
+      }
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
+        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
         config:
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
             name: local_route
             virtual_hosts:
-            - name: local_login_service
+            - name: local_access_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
                 route:
-                  cluster: login_cluster
+                  cluster: access_cluster
                   max_grpc_timeout: 0s
               cors:
-                allow_origin: "*"
+                allow_origin_string_match:
+                  - safe_regex:
+                      google_re2: {}
+                      regex: \*
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
@@ -36,10 +46,14 @@ static_resources:
           - name: envoy.router
   - name: dictionary_listener
     address:
-      socket_address: { address: 0.0.0.0, port_value: 8990 }
+      socket_address: {
+        address: 0.0.0.0,
+        port_value: 8990
+      }
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
+        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
         config:
           codec_type: auto
           stat_prefix: ingress_http
@@ -54,7 +68,10 @@ static_resources:
                   cluster: dictionary_cluster
                   max_grpc_timeout: 0s
               cors:
-                allow_origin: "*"
+                allow_origin_string_match:
+                  - safe_regex:
+                      google_re2: {}
+                      regex: \*
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
@@ -63,27 +80,34 @@ static_resources:
           - name: envoy.grpc_web
           - name: envoy.cors
           - name: envoy.router
-  - name: data_listener
+  - name: business_data_listener
     address:
-      socket_address: { address: 0.0.0.0, port_value: 8991 }
+      socket_address: {
+        address: 0.0.0.0,
+        port_value: 8991
+      }
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
+        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
         config:
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
             name: local_route
             virtual_hosts:
-            - name: local_data_service
+            - name: local_business_data_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
                 route:
-                  cluster: data_cluster
+                  cluster: business_data_cluster
                   max_grpc_timeout: 0s
               cors:
-                allow_origin: "*"
+                allow_origin_string_match:
+                  - safe_regex:
+                      google_re2: {}
+                      regex: \*
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
@@ -94,10 +118,14 @@ static_resources:
           - name: envoy.router
   - name: enrollment_listener
     address:
-      socket_address: { address: 0.0.0.0, port_value: 8992 }
+      socket_address: {
+        address: 0.0.0.0,
+        port_value: 8992
+      }
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
+        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
         config:
           codec_type: auto
           stat_prefix: ingress_http
@@ -112,7 +140,10 @@ static_resources:
                   cluster: enrollment_cluster
                   max_grpc_timeout: 0s
               cors:
-                allow_origin: "*"
+                allow_origin_string_match:
+                  - safe_regex:
+                      google_re2: {}
+                      regex: \*
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
@@ -121,28 +152,68 @@ static_resources:
           - name: envoy.grpc_web
           - name: envoy.cors
           - name: envoy.router
+
   clusters:
-  - name: login_cluster
+  - name: access_cluster
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: localhost, port_value: 50050 }}]
+    load_assignment:
+      cluster_name: access_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # replace the 'localhost' address with your access host address
+                address: localhost
+                port_value: 50050
+
   - name: dictionary_cluster
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: localhost, port_value: 50051 }}]
-  - name: data_cluster
+    load_assignment:
+      cluster_name: dictionary_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # replace the 'localhost' address with your dictionary host address
+                address: localhost
+                port_value: 50051
+
+  - name: business_data_cluster
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: localhost, port_value: 50052 }}]
+    load_assignment:
+      cluster_name: business_data_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # replace the 'localhost' address with your business data host address
+                address: localhost
+                port_value: 50052
+
   - name: enrollment_cluster
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: localhost, port_value: 50047 }}]
+    load_assignment:
+      cluster_name: business_data_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # replace the 'localhost' address with your enrollment host address
+                address: localhost
+                port_value: 50047


### PR DESCRIPTION
Fixed the error that prevents the container from starting, due to the deprecated option `'envoy.api.v2.route.CorsPolicy.allow_origin'` that was updated to `'envoy.api.v2.route.CorsPolicy.allow_origin_string_match'` also updated the deprecated option `'envoy.api.v2.Cluster.hosts'` by `'envoy.api.v2.Cluster.load_assignment'` option. 

To do: Fix the deprecated option `'envoy.api.v2.listener.Filter.config'` to `'envoy.api.v2.listener.Filter.typed_config'`.

fix #2 