### PR TITLE
fix #4: Deprecated option 'Filter.config'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Envoy proxy for gRPC as Example
 - [Docker Compose](https://docs.docker.com/compose/)
 - [Docker](https://docs.docker.com/)
 
+## Prepare YAML configuration file
+The addresses to which the servers should point in the envoy.yaml file must be changed, in the section `cluster` > `load_assignment` > `lb_endpoints` > `endpoint` > `address` > `socket_address`. There you specify the address of the host and the port where it will be accessed:
+
+```yaml
+  address:
+      socket_address:
+        # replace the 'localhost' address with your access host address
+        address: localhost
+
+        # it is the default port, unless the server port is changed it is recommended not to change
+        port_value: 50050
+```
+
+There are 4 clusters in total to Access (`access_cluster`), Dictionary (`dictionary_cluster`), Business Data (`business_data_cluster`) and Enrollment (`enrollment_cluster`), each with different ports pointed to the localhot address by default.
+
 ### Running Envoy proxy for it:
 Go to gRPC-Envoy-Proxy and run follow command (This command bluid a dockerfile from envoy.yml):
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -195,6 +195,8 @@ static_resources:
               socket_address:
                 # replace the 'localhost' address with your access host address
                 address: localhost
+                # it is the default port, unless the server port is changed it is recommended not to change
+                # https://github.com/erpcya/adempiere-gRPC-Server/blob/master/src/main/java/org/spin/grpc/util/AccessServer.java#L128
                 port_value: 50050
 
   - name: dictionary_cluster
@@ -211,6 +213,8 @@ static_resources:
               socket_address:
                 # replace the 'localhost' address with your dictionary host address
                 address: localhost
+                # it is the default port, unless the server port is changed it is recommended not to change
+                # https://github.com/erpcya/adempiere-gRPC-Server/blob/master/src/main/java/org/spin/grpc/util/DictionaryServer.java#L128
                 port_value: 50051
 
   - name: business_data_cluster
@@ -227,6 +231,8 @@ static_resources:
               socket_address:
                 # replace the 'localhost' address with your business data host address
                 address: localhost
+                # it is the default port, unless the server port is changed it is recommended not to change
+                # https://github.com/erpcya/adempiere-gRPC-Server/blob/master/src/main/java/org/spin/grpc/util/BusinessDataServer.java#L128
                 port_value: 50052
 
   - name: enrollment_cluster
@@ -235,7 +241,7 @@ static_resources:
     http2_protocol_options: {}
     lb_policy: round_robin
     load_assignment:
-      cluster_name: business_data_cluster
+      cluster_name: enrollment_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -243,4 +249,6 @@ static_resources:
               socket_address:
                 # replace the 'localhost' address with your enrollment host address
                 address: localhost
+                # it is the default port, unless the server port is changed it is recommended not to change
+                # https://github.com/erpcya/adempiere-gRPC-Server/blob/master/src/main/java/org/spin/grpc/util/EnrollmentServer.java#L127
                 port_value: 50047

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -17,33 +17,40 @@ static_resources:
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
-        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
-        config:
-          codec_type: auto
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
-            name: local_route
+            name: local_route_access
             virtual_hosts:
             - name: local_access_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route:
-                  cluster: access_cluster
+                route: {
+                  cluster: access_cluster,
                   max_grpc_timeout: 0s
+                }
               cors:
                 allow_origin_string_match:
                   - safe_regex:
                       google_re2: {}
                       regex: \*
-                allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # This directive holds the list of HTTP request methods. If the
+                # requests are more than one then the request are separated by commas.
+                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
+                # is a response-type header that is used to indicate the HTTP headers.
+                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
                 max_age: "1728000"
-                expose_headers: custom-header-1,grpc-status,grpc-message
+                # Is a response header that is used to expose the headers that have been mentioned in it.
+                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors
           - name: envoy.router
+
   - name: dictionary_listener
     address:
       socket_address: {
@@ -53,33 +60,40 @@ static_resources:
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
-        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
-        config:
-          codec_type: auto
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
-            name: local_route
+            name: local_route_dictionary
             virtual_hosts:
             - name: local_dictionary_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route:
-                  cluster: dictionary_cluster
+                route: {
+                  cluster: dictionary_cluster,
                   max_grpc_timeout: 0s
+                }
               cors:
                 allow_origin_string_match:
                   - safe_regex:
                       google_re2: {}
                       regex: \*
-                allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # This directive holds the list of HTTP request methods. If the
+                # requests are more than one then the request are separated by commas.
+                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
+                # is a response-type header that is used to indicate the HTTP headers.
+                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
                 max_age: "1728000"
-                expose_headers: custom-header-1,grpc-status,grpc-message
+                # Is a response header that is used to expose the headers that have been mentioned in it.
+                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors
           - name: envoy.router
+
   - name: business_data_listener
     address:
       socket_address: {
@@ -89,33 +103,40 @@ static_resources:
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
-        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
-        config:
-          codec_type: auto
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
-            name: local_route
+            name: local_route_business_data
             virtual_hosts:
             - name: local_business_data_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route:
-                  cluster: business_data_cluster
+                route: {
+                  cluster: business_data_cluster,
                   max_grpc_timeout: 0s
+                }
               cors:
                 allow_origin_string_match:
                   - safe_regex:
                       google_re2: {}
                       regex: \*
-                allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # This directive holds the list of HTTP request methods. If the
+                # requests are more than one then the request are separated by commas.
+                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
+                # is a response-type header that is used to indicate the HTTP headers.
+                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
                 max_age: "1728000"
-                expose_headers: custom-header-1,grpc-status,grpc-message
+                # Is a response header that is used to expose the headers that have been mentioned in it.
+                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors
           - name: envoy.router
+
   - name: enrollment_listener
     address:
       socket_address: {
@@ -125,29 +146,35 @@ static_resources:
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
-        # TODO: deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
-        config:
-          codec_type: auto
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
-            name: local_route
+            name: local_route_enrollment
             virtual_hosts:
             - name: local_enrollment_service
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route:
-                  cluster: enrollment_cluster
+                route: {
+                  cluster: enrollment_cluster,
                   max_grpc_timeout: 0s
+                }
               cors:
                 allow_origin_string_match:
                   - safe_regex:
                       google_re2: {}
                       regex: \*
-                allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # This directive holds the list of HTTP request methods. If the
+                # requests are more than one then the request are separated by commas.
+                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
+                # is a response-type header that is used to indicate the HTTP headers.
+                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
                 max_age: "1728000"
-                expose_headers: custom-header-1,grpc-status,grpc-message
+                # Is a response header that is used to expose the headers that have been mentioned in it.
+                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors


### PR DESCRIPTION
The warning generated by the log is fixed:

> [2020-02-12 20:27:02.416][6][warning][misc] [source/common/protobuf/utility.cc:441] Using deprecated option 'envoy.api.v2.listener.Filter.config' from file listener_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated for details.,

#### Old configuration: 
```yaml
    filter_chains:
    - filters:
      - name: envoy.http_connection_manager
        # deprecated option 'envoy.api.v2.listener.Filter.config' change to 'typed_config'
        config:
          codec_type: auto
          stat_prefix: ingress_htt
```
#### Updated configuration by:
```yaml
    filter_chains:
    - filters:
      - name: envoy.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
          codec_type: AUTO
          stat_prefix: ingress_htt
```

#### Log output:
```
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:251] initializing epoch 0 (hot restart version=11.104),
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:253] statically linked extensions:,
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:255]   envoy.filters.network: envoy.client_ssl_auth, envoy.echo, envoy.ext_authz, envoy.filters.network.dubbo_proxy, envoy.filters.network.kafka_broker, envoy.filters.network.local_ratelimit, envoy.filters.network.mysql_proxy, envoy.filters.network.rbac, envoy.filters.network.sni_cluster, envoy.filters.network.thrift_proxy, envoy.filters.network.zookeeper_proxy, envoy.http_connection_manager, envoy.mongo_proxy, envoy.ratelimit, envoy.redis_proxy, envoy.tcp_proxy,
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:255]   envoy.health_checkers: envoy.health_checkers.redis,
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:255]   envoy.filters.listener: envoy.listener.http_inspector, envoy.listener.original_dst, envoy.listener.original_src, envoy.listener.proxy_protocol, envoy.listener.tls_inspector,
[2020-02-13 16:22:29.808][6][info][main] [source/server/server.cc:255]   envoy.grpc_credentials: envoy.grpc_credentials.aws_iam, envoy.grpc_credentials.default, envoy.grpc_credentials.file_based_metadata,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.access_loggers: envoy.file_access_log, envoy.http_grpc_access_log, envoy.tcp_grpc_access_log,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.dubbo_proxy.serializers: dubbo.hessian2,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.transport_sockets.downstream: envoy.transport_sockets.alts, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.tap, envoy.transport_sockets.tls, raw_buffer, tls,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.filters.udp_listener: envoy.filters.udp_listener.udp_proxy,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.filters.http: envoy.buffer, envoy.cors, envoy.csrf, envoy.ext_authz, envoy.fault, envoy.filters.http.adaptive_concurrency, envoy.filters.http.dynamic_forward_proxy, envoy.filters.http.grpc_http1_reverse_bridge, envoy.filters.http.grpc_stats, envoy.filters.http.header_to_metadata, envoy.filters.http.jwt_authn, envoy.filters.http.on_demand, envoy.filters.http.original_src, envoy.filters.http.rbac, envoy.filters.http.tap, envoy.grpc_http1_bridge, envoy.grpc_json_transcoder, envoy.grpc_web, envoy.gzip, envoy.health_check, envoy.http_dynamo_filter, envoy.ip_tagging, envoy.lua, envoy.rate_limit, envoy.router, envoy.squash,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.dubbo_proxy.route_matchers: default,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.dubbo_proxy.filters: envoy.filters.dubbo.router,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.clusters: envoy.cluster.eds, envoy.cluster.logical_dns, envoy.cluster.original_dst, envoy.cluster.static, envoy.cluster.strict_dns, envoy.clusters.aggregate, envoy.clusters.dynamic_forward_proxy, envoy.clusters.redis,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.resource_monitors: envoy.resource_monitors.fixed_heap, envoy.resource_monitors.injected_resource,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.stats_sinks: envoy.dog_statsd, envoy.metrics_service, envoy.stat_sinks.hystrix, envoy.statsd,
[2020-02-13 16:22:29.809][6][info][main] [source/server/server.cc:255]   envoy.thrift_proxy.filters: envoy.filters.thrift.rate_limit, envoy.filters.thrift.router,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.dubbo_proxy.protocols: dubbo,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.resolvers: envoy.ip,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.thrift_proxy.transports: auto, framed, header, unframed,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.retry_host_predicates: envoy.retry_host_predicates.omit_canary_hosts, envoy.retry_host_predicates.previous_hosts,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.transport_sockets.upstream: envoy.transport_sockets.alts, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.tap, envoy.transport_sockets.tls, raw_buffer, tls,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.udp_listeners: raw_udp_listener,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.thrift_proxy.protocols: auto, binary, binary/non-strict, compact, twitter,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.tracers: envoy.dynamic.ot, envoy.lightstep, envoy.tracers.datadog, envoy.tracers.opencensus, envoy.tracers.xray, envoy.zipkin,
[2020-02-13 16:22:29.810][6][info][main] [source/server/server.cc:255]   envoy.retry_priorities: envoy.retry_priorities.previous_priorities,
[2020-02-13 16:22:29.826][6][info][main] [source/server/server.cc:336] admin address: 0.0.0.0:9902,
[2020-02-13 16:22:29.829][6][info][main] [source/server/server.cc:455] runtime: layers:,
  - name: base,
    static_layer:,
      {},
  - name: admin,
    admin_layer:,
      {},
[2020-02-13 16:22:29.829][6][info][config] [source/server/configuration_impl.cc:62] loading 0 static secret(s),
[2020-02-13 16:22:29.830][6][info][config] [source/server/configuration_impl.cc:68] loading 4 cluster(s),
[2020-02-13 16:22:29.835][6][info][upstream] [source/common/upstream/cluster_manager_impl.cc:171] cm init: all clusters initialized,
[2020-02-13 16:22:29.835][6][info][config] [source/server/configuration_impl.cc:72] loading 4 listener(s),
[2020-02-13 16:22:29.846][6][info][config] [source/server/configuration_impl.cc:97] loading tracing configuration,
[2020-02-13 16:22:29.846][6][info][config] [source/server/configuration_impl.cc:116] loading stats sink configuration,
[2020-02-13 16:22:29.846][6][info][main] [source/server/server.cc:529] all clusters initialized. initializing init manager,
[2020-02-13 16:22:29.846][6][info][config] [source/server/listener_manager_impl.cc:707] all dependencies initialized. starting workers,
[2020-02-13 16:22:29.846][6][info][main] [source/server/server.cc:550] starting main dispatch loop,
[2020-02-13 16:37:29.851][6][info][main] [source/server/drain_manager_impl.cc:68] shutting down parent after drain,
```

**Note:** Documentation is also added to configure the addresses and ports in the `envoy.yaml` file.
#4 