### PR TITLE
Improve: Set multiple routes for single-port services.

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -8,10 +8,11 @@ admin:
 
 static_resources:
   listeners:
-  - name: access_listener
+  - name: local_listener
     address:
       socket_address: {
         address: 0.0.0.0,
+        # port of this proxy route
         port_value: 8989
       }
     filter_chains:
@@ -27,137 +28,44 @@ static_resources:
             - name: local_access_service
               domains: ["*"]
               routes:
-              - match: { prefix: "/" }
+              - match: {
+                  # entry path for requests that will go to the access server
+                  prefix: "/access/"
+                  # prefix: "/access"
+                }
                 route: {
+                  # switches the route prefix to this value
+                  prefix_rewrite: "/",
                   cluster: access_cluster,
                   max_grpc_timeout: 0s
                 }
-              cors:
-                allow_origin_string_match:
-                  - safe_regex:
-                      google_re2: {}
-                      regex: \*
-                # This directive holds the list of HTTP request methods. If the
-                # requests are more than one then the request are separated by commas.
-                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
-                # is a response-type header that is used to indicate the HTTP headers.
-                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
-                max_age: "1728000"
-                # Is a response header that is used to expose the headers that have been mentioned in it.
-                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
-          http_filters:
-          - name: envoy.grpc_web
-          - name: envoy.cors
-          - name: envoy.router
-
-  - name: dictionary_listener
-    address:
-      socket_address: {
-        address: 0.0.0.0,
-        port_value: 8990
-      }
-    filter_chains:
-    - filters:
-      - name: envoy.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route_dictionary
-            virtual_hosts:
-            - name: local_dictionary_service
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
+              - match: {
+                  # entry path for requests that will go to the dictionary server
+                  prefix: "/dictionary/"
+                }
                 route: {
+                  # switches the route prefix to this value
+                  prefix_rewrite: "/",
                   cluster: dictionary_cluster,
                   max_grpc_timeout: 0s
                 }
-              cors:
-                allow_origin_string_match:
-                  - safe_regex:
-                      google_re2: {}
-                      regex: \*
-                # This directive holds the list of HTTP request methods. If the
-                # requests are more than one then the request are separated by commas.
-                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
-                # is a response-type header that is used to indicate the HTTP headers.
-                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
-                max_age: "1728000"
-                # Is a response header that is used to expose the headers that have been mentioned in it.
-                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
-          http_filters:
-          - name: envoy.grpc_web
-          - name: envoy.cors
-          - name: envoy.router
-
-  - name: business_data_listener
-    address:
-      socket_address: {
-        address: 0.0.0.0,
-        port_value: 8991
-      }
-    filter_chains:
-    - filters:
-      - name: envoy.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route_business_data
-            virtual_hosts:
-            - name: local_business_data_service
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
+              - match: {
+                  # entry path for requests that will go to the businessdata server
+                  prefix: "/businessdata/"
+                }
                 route: {
+                  # switches the route prefix to this value
+                  prefix_rewrite: "/",
                   cluster: business_data_cluster,
                   max_grpc_timeout: 0s
                 }
-              cors:
-                allow_origin_string_match:
-                  - safe_regex:
-                      google_re2: {}
-                      regex: \*
-                # This directive holds the list of HTTP request methods. If the
-                # requests are more than one then the request are separated by commas.
-                allow_methods: GET, PUT, DELETE, POST, PATCH, OPTIONS
-                # is a response-type header that is used to indicate the HTTP headers.
-                allow_headers: authorization,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                # It specifies how many maximum seconds can the result be cached. Note: If -1 is present then caching is disabled.
-                max_age: "1728000"
-                # Is a response header that is used to expose the headers that have been mentioned in it.
-                expose_headers: custom-header-1,grpc-status,grpc-message,x-envoy-upstream-service-time
-          http_filters:
-          - name: envoy.grpc_web
-          - name: envoy.cors
-          - name: envoy.router
-
-  - name: enrollment_listener
-    address:
-      socket_address: {
-        address: 0.0.0.0,
-        port_value: 8992
-      }
-    filter_chains:
-    - filters:
-      - name: envoy.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route_enrollment
-            virtual_hosts:
-            - name: local_enrollment_service
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
+              - match: {
+                  # entry path for requests that will go to the enrollment server
+                  prefix: "/enrollment/"
+                }
                 route: {
+                  # switches the route prefix to this value
+                  prefix_rewrite: "/",
                   cluster: enrollment_cluster,
                   max_grpc_timeout: 0s
                 }


### PR DESCRIPTION
A rupture change is introduced. Prior to this PR the different services are accessed in the following way by default:

* Access: `localhost:8989`
* Dictionary: `localhost:8990`
* Business Data: `localhost:8991`
* Enrollment: `localhost:8992`

With this PR it is not necessary to use 4 different ports, you can access from a single port using routes for each service, by default it is as follows:

* Access: `localhost:8989/access`
* Dictionary: `localhost:8989/dictionary`
* Business Data: `localhost:8989/businessdata`
* Enrollment: `localhost:8989/enrollment`
